### PR TITLE
Add analytics logging to user service

### DIFF
--- a/user-service/app/main.py
+++ b/user-service/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
+import asyncio, httpx
 
 from . import models, schemas, auth
 from .database import Base, engine, get_db
@@ -10,6 +11,26 @@ Base.metadata.create_all(bind=engine)
 # Initialize FastAPI app and router
 app = FastAPI()
 router = APIRouter(prefix="/user", tags=["user"])
+
+# ──────────────────────── ANALYTICS HELPER ───────────────────────
+def _log_event_async(service: str, event_type: str, metadata: dict) -> None:
+    """Fire-and-forget analytics call (never blocks endpoints)."""
+
+    async def _send() -> None:
+        try:
+            async with httpx.AsyncClient(verify=False, timeout=3) as c:
+                await c.post(
+                    "http://analytics-service:80/analytics/",
+                    json={
+                        "service": service,
+                        "event_type": event_type,
+                        "metadata": metadata,
+                    },
+                )
+        except Exception as exc:  # swallow errors – analytics must never break prod
+            print(f"[analytics] failed: {exc}")
+
+    asyncio.create_task(_send())
 
 
 @router.post("/register", status_code=status.HTTP_201_CREATED)
@@ -25,6 +46,11 @@ def register(user: schemas.UserCreate, db: Session = Depends(get_db)):
     db.add(db_user)
     db.commit()
     db.refresh(db_user)
+    _log_event_async(
+        "user-service",
+        "user_registered",
+        {"email": db_user.email},
+    )
     return {"email": db_user.email}
 
 
@@ -36,6 +62,12 @@ def login(user: schemas.UserCreate, db: Session = Depends(get_db)):
         user.password, db_user.hashed_password
     ):
         raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    _log_event_async(
+        "user-service",
+        "user_login",
+        {"email": user.email},
+    )
 
     return {"message": "Login successful"}
 

--- a/user-service/requirements.txt
+++ b/user-service/requirements.txt
@@ -7,4 +7,6 @@ pydantic[email]
 python-dotenv    # optional but handy locally
 pydantic-settings
 bcrypt==4.0.1
+httpx
+asyncio
 


### PR DESCRIPTION
## Summary
- add asynchronous analytics helper to user-service
- emit `user_registered` and `user_login` events
- include `httpx` and `asyncio` in service dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685c4b8633d08324bc46b7ba5f53ef1f